### PR TITLE
made memory bro update on save command when open

### DIFF
--- a/lib/memory-bro.coffee
+++ b/lib/memory-bro.coffee
@@ -14,7 +14,8 @@ module.exports = MemoryBro =
       @subscriptions = new CompositeDisposable
 
       # Register command that toggles this view
-      @subscriptions.add atom.commands.add 'atom-workspace', 'memory-bro:toggle': => @toggle()
+      @subscriptions.add atom.commands.add 'atom-workspace', 'memory-bro:toggle': => @toggle('toggle')
+      @subscriptions.add atom.commands.add 'atom-workspace', 'core:save': => @toggle('save')
 
    deactivate: ->
       @modalPanel.destroy()
@@ -114,11 +115,12 @@ module.exports = MemoryBro =
 
       return loop_infos
 
-   toggle: ->
-      if @modalPanel.isVisible()
+   toggle: (type) ->
+      if @modalPanel.isVisible() && type=='toggle'
          @modalPanel.hide()
          @memoryBroView.clearDOM()
-      else
+      else if((!@modalPanel.isVisible() && type=='toggle') || (type=='save' && @modalPanel.isVisible()))
+         @memoryBroView.clearDOM()
          @memoryBroView.updateStatusBar()
          console.log 'MemoryBro was toggled!'
          loop_infos = @findLoops()


### PR DESCRIPTION
When using memory bro I found it annoying to open and close it just to update. I feel as though it would be convenient to have it update upon saving the file if left open. That way, when fixing allocation errors, the user does not have to close and re-open memory bro.
